### PR TITLE
Stop Renovate from duplicating Dependabot's github-actions and security PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "github-actions": {
+    "enabled": false
+  },
+  "vulnerabilityAlerts": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
## Summary
This repo runs both Dependabot (\`.github/dependabot.yml\`, scoped to \`github-actions\`) and Renovate (\`renovate.json\`, \`config:recommended\`). Renovate's recommended preset also covers github-actions and raises its own vulnerability-fix PRs, so the two bots were fighting over the same updates:

- #246 (Renovate, checkout→v7) vs #243 (Dependabot, checkout→v6.0.2) — merged #246, closed #243
- #223 (Renovate, artifact actions→v7/v8) vs #240 + #238 (Dependabot, same) — merged #223, closed #240/#238
- #239 (Renovate, cryptography security fix) — already superseded by #247, auto-closed by Renovate itself
- #236 (Dependabot, pyasn1 security fix) — superseded by #247, closed manually

This PR disables Renovate for \`github-actions\` and \`vulnerabilityAlerts\` so Dependabot stays the sole authority for both going forward. Renovate keeps handling \`pyproject.toml\` and \`.python-version\` currency, which Dependabot has no config for here.

## Test plan
- [x] renovate.json validated as syntactically correct JSON
- [ ] Confirm Renovate stops opening github-actions/vulnerability PRs on its next run