### PR TITLE
Security hardening: WebSocket Origin validation, SSRF, XSS, plan confirmation bypass, path traversal (v0.20.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1327,6 +1327,18 @@ mcp-cli --log-file ~/.mcp-cli/logs/debug.log --server sqlite
 - **XSS Prevention**: Tool names and user-supplied content are HTML-escaped before template injection
 - **URL Scheme Validation**: `ui/open-link` only allows `http://` and `https://` schemes
 - **Tool Name Validation**: Bridge rejects tool names not matching the MCP spec character set
+- **WebSocket Origin Validation** (v0.20.1+): The local app-host server rejects any WebSocket handshake whose `Origin` header doesn't match its own `http://localhost:<port>` host page, so an unrelated webpage can't attach to a running app's bridge
+- **Tool Permission Enforcement** (v0.20.1+): When a resource declares an allow-list of tools it may call, the bridge enforces it on every `tools/call` — not just a tool-name syntax check
+- **SSRF-Safe Resource Fetch** (v0.20.1+): Direct HTTP(S) resource fetches are validated against private/loopback/link-local address ranges before connecting, and re-validated at every redirect hop
+
+### Dashboard Security (v0.20.1+)
+- **WebSocket Origin Validation**: The dashboard's WebSocket server applies the same Origin check as MCP Apps
+- **Sanitized Markdown Rendering**: Assistant chat messages are rendered through DOMPurify rather than a hand-rolled sanitizer
+- **Escaped View Metadata**: Server-declared view names and icons are HTML-escaped before being inserted into panel headers
+- **Sanitized Agent/Session Paths**: Agent and session identifiers are sanitized before use as filesystem path components
+
+### Plan Execution Security (v0.20.1+)
+- **Tool Confirmation Enforced**: Plan execution (`/plan`, `plan_create_and_execute`) honors the same confirm-tools preference and trusted-domain policy as the interactive chat path; if confirmation is required and no prompt is available, the call is declined rather than executed unconfirmed
 
 ## 🚀 Performance Features
 

--- a/docs/MCP_APPS.md
+++ b/docs/MCP_APPS.md
@@ -134,6 +134,18 @@ The bridge rejects tool names not matching `^[a-zA-Z0-9_\-./]+$` per the MCP spe
 
 `_safe_json_dumps()` falls back to `_to_serializable()` on `TypeError`/`ValueError`, with circular reference protection via a visited-object set.
 
+### WebSocket Origin Validation (v0.20.1+)
+
+The local app-host server validates the `Origin` header on every WebSocket upgrade request against the `http://localhost:<port>` (or `127.0.0.1`) host page origin, via `mcp_cli.utils.loopback_origin.is_allowed_origin()`. Browsers attach an `Origin` header to WebSocket handshakes automatically but don't enforce same-origin policy on the connection itself — enforcement has to happen server-side. Handshakes with a mismatched or missing Origin are rejected with HTTP 403 before the upgrade completes.
+
+### Tool Permission Enforcement (v0.20.1+)
+
+`AppInfo.permissions` (from the resource's `_meta.ui.permissions`) is enforced in `AppBridge._handle_tool_call()`: if a resource declares a `tools` allow-list, only tools on that list can be invoked via the bridge, in addition to the existing tool-name syntax check. A resource that declares no permissions keeps the previous unrestricted behavior.
+
+### SSRF-Safe Resource Fetch (v0.20.1+)
+
+Direct HTTP(S) fetches (for `resource_uri` or a tool result's `viewUrl`) are validated with `mcp_cli.utils.url_safety.is_safe_fetch_url()`, which resolves the hostname and rejects private, loopback, link-local, and other non-public address ranges. Redirects are followed manually so each hop is re-validated rather than trusted after the first check.
+
 ## Session Reliability
 
 ### Deferred Tool Result Delivery

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-cli"
-version = "0.20.0"
+version = "0.20.1"
 description = "A cli for the Model Context Provider"
 requires-python = ">=3.11"
 readme = "README.md"

--- a/src/mcp_cli/agents/group_store.py
+++ b/src/mcp_cli/agents/group_store.py
@@ -19,6 +19,8 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from mcp_cli.chat.session_store import _sanitize_path_component
+
 if TYPE_CHECKING:
     from mcp_cli.agents.manager import AgentManager
 
@@ -69,9 +71,11 @@ async def save_group(
             }
         )
 
-        # Save session if available
+        # Save session if available. agent_id can originate from an
+        # LLM-controllable agent_spawn tool call, so sanitize it before
+        # using it as a path component.
         ctx = snapshot["context"]
-        agent_dir = base / agent_id
+        agent_dir = base / _sanitize_path_component(agent_id)
         agent_dir.mkdir(parents=True, exist_ok=True)
         try:
             history = getattr(ctx, "conversation_history", [])

--- a/src/mcp_cli/apps/bridge.py
+++ b/src/mcp_cli/apps/bridge.py
@@ -146,6 +146,24 @@ class AppBridge:
                 }
             )
 
+        if not self._is_tool_permitted(tool_name):
+            logger.warning(
+                "App %s attempted to call tool %r outside its declared "
+                "permission scope",
+                self.app_info.tool_name,
+                tool_name,
+            )
+            return json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "error": {
+                        "code": -32603,
+                        "message": f"Tool not permitted: {tool_name!r}",
+                    },
+                }
+            )
+
         logger.debug(
             "App %s calling tool %s with %s",
             self.app_info.tool_name,
@@ -209,6 +227,25 @@ class AppBridge:
                     "error": {"code": -32000, "message": str(e)},
                 }
             )
+
+    def _is_tool_permitted(self, tool_name: str) -> bool:
+        """Check *tool_name* against the resource's declared permission scope.
+
+        ``self.app_info.permissions`` comes from the resource's own
+        ``_meta.ui.permissions`` — a scope the *server* declared, not
+        something mcp-cli invents. When a resource declares a ``tools``
+        allow-list, only those tools may be invoked via this bridge. A
+        resource that declares no permissions (or a permissions dict with
+        no ``tools`` key) hasn't opted into scoping, so nothing here
+        restricts it beyond the existing tool-name syntax check.
+        """
+        permissions = self.app_info.permissions
+        if not permissions:
+            return True
+        allowed_tools = permissions.get("tools")
+        if not isinstance(allowed_tools, list):
+            return True
+        return tool_name in allowed_tools
 
     # ------------------------------------------------------------------ #
     #  Handler: resources/read                                            #

--- a/src/mcp_cli/apps/host.py
+++ b/src/mcp_cli/apps/host.py
@@ -18,6 +18,7 @@ import logging
 import re
 import webbrowser
 from typing import Any, TYPE_CHECKING
+from urllib.parse import urlsplit
 
 try:
     import websockets
@@ -50,6 +51,31 @@ _MCP_CLI_VERSION = "0.13"
 # Strict regex for CSP source values — reject anything that could break out
 # of an HTML attribute or inject additional directives.
 _SAFE_CSP_SOURCE = re.compile(r"^[a-zA-Z0-9\-.:/*]+$")
+
+# Loopback hostnames the host page can legitimately be served from.
+_ALLOWED_ORIGIN_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def _is_allowed_origin(origin: str | None, port: int) -> bool:
+    """Return True if *origin* is the http://localhost:<port> host page origin.
+
+    Real browsers always attach an Origin header to WebSocket handshakes,
+    but — unlike fetch()/XHR — do not enforce same-origin policy on the
+    connection itself; that enforcement is the server's job. Requiring an
+    exact match here (scheme, loopback host, and port) is what actually
+    prevents an unrelated page from attaching to this app's bridge.
+    """
+    if not origin:
+        return False
+    try:
+        parsed = urlsplit(origin)
+    except ValueError:
+        return False
+    if parsed.scheme != "http":
+        return False
+    if parsed.hostname not in _ALLOWED_ORIGIN_HOSTS:
+        return False
+    return parsed.port == port
 
 
 class AppHostServer:
@@ -355,6 +381,27 @@ class AppHostServer:
                     websockets.Headers({"Content-Length": str(len(body))}),
                     body,
                 )
+
+            # Reject cross-origin WebSocket upgrades. Browsers attach an
+            # Origin header to WS handshakes but do not enforce same-origin
+            # policy on them the way they do for fetch()/XHR — enforcement
+            # is the server's responsibility, so any page that knows (or
+            # scans for) this port could otherwise attach to the bridge.
+            origin = request.headers.get("Origin")
+            if not _is_allowed_origin(origin, app_info.port):
+                logger.warning(
+                    "Rejected WebSocket connection for app %s: disallowed Origin %r",
+                    app_info.tool_name,
+                    origin,
+                )
+                body = b"Forbidden"
+                return Response(
+                    http.HTTPStatus.FORBIDDEN,
+                    "Forbidden",
+                    websockets.Headers({"Content-Length": str(len(body))}),
+                    body,
+                )
+
             # Return None to proceed with WebSocket upgrade for /ws
             return None
 

--- a/src/mcp_cli/apps/host.py
+++ b/src/mcp_cli/apps/host.py
@@ -18,7 +18,6 @@ import logging
 import re
 import webbrowser
 from typing import Any, TYPE_CHECKING
-from urllib.parse import urlsplit
 
 try:
     import websockets
@@ -39,6 +38,7 @@ from mcp_cli.config.defaults import (
     DEFAULT_APP_MAX_CONCURRENT,
     DEFAULT_HTTP_REQUEST_TIMEOUT,
 )
+from mcp_cli.utils.loopback_origin import is_allowed_origin as _is_allowed_origin
 
 if TYPE_CHECKING:
     from mcp_cli.tools.manager import ToolManager
@@ -51,31 +51,6 @@ _MCP_CLI_VERSION = "0.13"
 # Strict regex for CSP source values — reject anything that could break out
 # of an HTML attribute or inject additional directives.
 _SAFE_CSP_SOURCE = re.compile(r"^[a-zA-Z0-9\-.:/*]+$")
-
-# Loopback hostnames the host page can legitimately be served from.
-_ALLOWED_ORIGIN_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
-
-
-def _is_allowed_origin(origin: str | None, port: int) -> bool:
-    """Return True if *origin* is the http://localhost:<port> host page origin.
-
-    Real browsers always attach an Origin header to WebSocket handshakes,
-    but — unlike fetch()/XHR — do not enforce same-origin policy on the
-    connection itself; that enforcement is the server's job. Requiring an
-    exact match here (scheme, loopback host, and port) is what actually
-    prevents an unrelated page from attaching to this app's bridge.
-    """
-    if not origin:
-        return False
-    try:
-        parsed = urlsplit(origin)
-    except ValueError:
-        return False
-    if parsed.scheme != "http":
-        return False
-    if parsed.hostname not in _ALLOWED_ORIGIN_HOSTS:
-        return False
-    return parsed.port == port
 
 
 class AppHostServer:

--- a/src/mcp_cli/apps/host.py
+++ b/src/mcp_cli/apps/host.py
@@ -39,6 +39,7 @@ from mcp_cli.config.defaults import (
     DEFAULT_HTTP_REQUEST_TIMEOUT,
 )
 from mcp_cli.utils.loopback_origin import is_allowed_origin as _is_allowed_origin
+from mcp_cli.utils.url_safety import is_safe_fetch_url
 
 if TYPE_CHECKING:
     from mcp_cli.tools.manager import ToolManager
@@ -441,28 +442,51 @@ class AppHostServer:
             f"Could not find available port after {max_attempts} attempts"
         )
 
+    _MAX_REDIRECTS = 5
+
     @staticmethod
     async def _fetch_http_resource(url: str) -> tuple[str, dict[str, Any]]:
-        """Fetch HTML content directly from an HTTP/HTTPS URL."""
+        """Fetch HTML content directly from an HTTP/HTTPS URL.
+
+        *url* comes from the connected MCP server (resource_uri or a tool
+        result's viewUrl), so it's validated against is_safe_fetch_url()
+        before every request — including each redirect hop, since a
+        same-origin-looking URL could redirect to an internal address.
+        """
         import httpx
 
+        current_url = url
         async with httpx.AsyncClient(
-            follow_redirects=True, timeout=DEFAULT_HTTP_REQUEST_TIMEOUT
+            follow_redirects=False, timeout=DEFAULT_HTTP_REQUEST_TIMEOUT
         ) as client:
-            resp = await client.get(url)
-            resp.raise_for_status()
-            html = resp.text
-            # Wrap in a resource-like structure for CSP/permissions extraction
-            resource = {
-                "contents": [
-                    {
-                        "uri": url,
-                        "mimeType": resp.headers.get("content-type", "text/html"),
-                        "text": html,
-                    }
-                ]
-            }
-            return html, resource
+            for _ in range(AppHostServer._MAX_REDIRECTS + 1):
+                if not is_safe_fetch_url(current_url):
+                    raise RuntimeError(
+                        f"Refusing to fetch disallowed URL: {current_url}"
+                    )
+                resp = await client.get(current_url)
+                if resp.is_redirect:
+                    location = resp.headers.get("location")
+                    if not location:
+                        resp.raise_for_status()
+                        break
+                    current_url = str(resp.url.join(location))
+                    continue
+                resp.raise_for_status()
+                html = resp.text
+                # Wrap in a resource-like structure for CSP/permissions extraction
+                resource = {
+                    "contents": [
+                        {
+                            "uri": current_url,
+                            "mimeType": resp.headers.get("content-type", "text/html"),
+                            "text": html,
+                        }
+                    ]
+                }
+                return html, resource
+
+        raise RuntimeError(f"Too many redirects fetching {url}")
 
     @staticmethod
     def _extract_html(resource: dict[str, Any]) -> str:

--- a/src/mcp_cli/chat/attachments.py
+++ b/src/mcp_cli/chat/attachments.py
@@ -267,6 +267,16 @@ def process_browser_file(
     ValueError
         If the file is too large or has an unsupported extension.
     """
+    # Reject grossly oversized payloads from the encoded length alone,
+    # before decoding the whole thing into memory (base64 inflates size by
+    # ~4/3, so this is a cheap upper-bound check ahead of the exact one
+    # below).
+    if len(data_b64) * 3 // 4 > DEFAULT_MAX_ATTACHMENT_SIZE_BYTES:
+        raise ValueError(
+            f"File too large: ~{len(data_b64) * 3 // 4:,} bytes "
+            f"(max {DEFAULT_MAX_ATTACHMENT_SIZE_BYTES:,})"
+        )
+
     raw = base64.b64decode(data_b64)
     size = len(raw)
     if size > DEFAULT_MAX_ATTACHMENT_SIZE_BYTES:

--- a/src/mcp_cli/chat/conversation.py
+++ b/src/mcp_cli/chat/conversation.py
@@ -161,7 +161,8 @@ class ConversationProcessor:
             max_turns: Maximum number of conversation turns before forcing exit (default: 100)
         """
         turn_count = 0
-        last_tool_signature = None  # Track last tool call to detect true duplicates
+        # Track last tool call to detect true duplicates
+        last_tool_signature: str | None = None
         tools_for_completion = None  # Will be set based on context
         after_tool_calls = False  # True when resuming after tool execution
 

--- a/src/mcp_cli/chat/session_store.py
+++ b/src/mcp_cli/chat/session_store.py
@@ -18,6 +18,16 @@ from mcp_cli.config.defaults import DEFAULT_AGENT_ID, DEFAULT_SESSIONS_DIR
 logger = logging.getLogger(__name__)
 
 
+def _sanitize_path_component(value: str) -> str:
+    """Strip path separators and '..' so *value* can't escape its parent dir.
+
+    Used for any identifier (session_id, agent_id) that ends up as a path
+    component but may originate from LLM-controllable input (e.g. an
+    agent_spawn tool call), not just direct user input.
+    """
+    return value.replace("/", "_").replace("\\", "_").replace("..", "_")
+
+
 class SessionMetadata(BaseModel):
     """Metadata for a saved session."""
 
@@ -57,16 +67,18 @@ class SessionStore:
         if sessions_dir is None:
             sessions_dir = Path(DEFAULT_SESSIONS_DIR).expanduser()
         self.agent_id = agent_id
-        # Agent-namespaced subdirectory
-        self.sessions_dir = sessions_dir / agent_id
+        # Agent-namespaced subdirectory — sanitized since agent_id can
+        # originate from an LLM-controllable agent_spawn tool call, not
+        # just direct user input.
+        safe_agent_id = _sanitize_path_component(agent_id)
+        self.sessions_dir = sessions_dir / safe_agent_id
         self.sessions_dir.mkdir(parents=True, exist_ok=True)
         # Keep reference to root for backward-compat migration
         self._root_dir = sessions_dir
 
     def _session_path(self, session_id: str) -> Path:
         """Get the file path for a session."""
-        # Sanitize session_id to prevent path traversal
-        safe_id = session_id.replace("/", "_").replace("\\", "_").replace("..", "_")
+        safe_id = _sanitize_path_component(session_id)
         return self.sessions_dir / f"{safe_id}.json"
 
     def save(self, data: SessionData) -> Path:
@@ -120,7 +132,7 @@ class SessionStore:
 
         Returns the new path if migration succeeded, None otherwise.
         """
-        safe_id = session_id.replace("/", "_").replace("\\", "_").replace("..", "_")
+        safe_id = _sanitize_path_component(session_id)
         legacy_path = self._root_dir / f"{safe_id}.json"
         if not legacy_path.exists() or not legacy_path.is_file():
             return None

--- a/src/mcp_cli/commands/cmd/cmd.py
+++ b/src/mcp_cli/commands/cmd/cmd.py
@@ -392,7 +392,7 @@ Usage:
                 messages=messages,
                 max_tokens=4096,
             )
-            return final_response.get("response", response_text)
+            return str(final_response.get("response", response_text))
         except Exception:
             return response_text
 

--- a/src/mcp_cli/commands/plan/plan.py
+++ b/src/mcp_cli/commands/plan/plan.py
@@ -12,6 +12,7 @@ from mcp_cli.commands.base import (
     CommandResult,
 )
 from mcp_cli.config.enums import PlanAction
+from mcp_cli.planning.backends import ConfirmPromptCallback
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +140,7 @@ Usage:
                     success=False,
                     error="Plan ID required. Usage: /plan resume <id>",
                 )
-            return await self._resume_plan(planning_context, remainder.strip())
+            return await self._resume_plan(planning_context, remainder.strip(), kwargs)
 
         else:
             return CommandResult(
@@ -301,6 +302,18 @@ Usage:
             if display:
                 await display.stop_tool_execution(result_text, success)
 
+        confirm_prompt: ConfirmPromptCallback | None = None
+        if ui_manager is not None and hasattr(ui_manager, "do_confirm_tool_execution"):
+
+            async def _confirm_prompt(tool_name: str, arguments: dict) -> bool:
+                return bool(
+                    await ui_manager.do_confirm_tool_execution(
+                        tool_name=tool_name, arguments=arguments
+                    )
+                )
+
+            confirm_prompt = _confirm_prompt
+
         # Get model_manager for LLM-driven execution
         model_manager = (kwargs or {}).get("model_manager")
 
@@ -311,6 +324,7 @@ Usage:
             on_step_complete=on_step_complete,
             on_tool_start=on_tool_start,
             on_tool_complete=on_tool_complete,
+            confirm_prompt=confirm_prompt,
         )
 
         result = await runner.execute_plan(plan_data, dry_run=dry_run)
@@ -347,7 +361,9 @@ Usage:
             error=f"Plan not found: {plan_id}",
         )
 
-    async def _resume_plan(self, context, plan_id: str) -> CommandResult:
+    async def _resume_plan(
+        self, context, plan_id: str, kwargs: dict | None = None
+    ) -> CommandResult:
         """Resume an interrupted plan."""
         from chuk_term.ui import output
         from mcp_cli.planning.executor import PlanRunner
@@ -359,7 +375,20 @@ Usage:
                 error=f"Plan not found: {plan_id}",
             )
 
-        runner = PlanRunner(context)
+        ui_manager = (kwargs or {}).get("ui_manager")
+        confirm_prompt: ConfirmPromptCallback | None = None
+        if ui_manager is not None and hasattr(ui_manager, "do_confirm_tool_execution"):
+
+            async def _confirm_prompt(tool_name: str, arguments: dict) -> bool:
+                return bool(
+                    await ui_manager.do_confirm_tool_execution(
+                        tool_name=tool_name, arguments=arguments
+                    )
+                )
+
+            confirm_prompt = _confirm_prompt
+
+        runner = PlanRunner(context, confirm_prompt=confirm_prompt)
         checkpoint = runner.load_checkpoint(plan_id)
 
         if not checkpoint:

--- a/src/mcp_cli/config/defaults.py
+++ b/src/mcp_cli/config/defaults.py
@@ -367,6 +367,10 @@ DEFAULT_MEMORY_MAX_ENTRIES_PER_SCOPE = 100
 DEFAULT_MEMORY_MAX_PROMPT_CHARS = 2000
 """Maximum characters for memory section in system prompt."""
 
+DEFAULT_MEMORY_MAX_ENTRY_CHARS = 10_000
+"""Maximum characters for a single memory entry's content, to bound
+on-disk growth from repeated remember() calls with large payloads."""
+
 
 # ================================================================
 # Planning Defaults (Tier 6)

--- a/src/mcp_cli/dashboard/server.py
+++ b/src/mcp_cli/dashboard/server.py
@@ -32,6 +32,8 @@ except ImportError:  # pragma: no cover
         "Dashboard support requires websockets. Install with:  pip install mcp-cli[dashboard]"
     )
 
+from mcp_cli.utils.loopback_origin import is_allowed_origin
+
 logger = logging.getLogger(__name__)
 
 _STATIC_DIR = Path(__file__).parent / "static"
@@ -43,6 +45,7 @@ class DashboardServer:
     def __init__(self) -> None:
         self._clients: set[ServerConnection] = set()
         self._server: Any = None
+        self._port: int = 0
         # Called when a browser user sends USER_MESSAGE / USER_ACTION / REQUEST_TOOL
         self.on_browser_message: Callable[..., Any] | None = None
         # Called when a new WebSocket client connects (before message loop starts)
@@ -66,6 +69,7 @@ class DashboardServer:
     async def start(self, port: int = 0) -> int:
         """Find an available port and start the server. Returns the bound port."""
         bound_port = await self._find_port(port)
+        self._port = bound_port
 
         self._server = await ws_serve(
             self._ws_handler,
@@ -186,8 +190,27 @@ class DashboardServer:
     ) -> Response | None:
         path = request.path.split("?")[0]  # strip query string
 
-        # WebSocket upgrade — let the library handle it
         if path == "/ws":
+            # Reject cross-origin WebSocket upgrades. Browsers attach an
+            # Origin header to WS handshakes but do not enforce same-origin
+            # policy on them the way they do for fetch()/XHR — enforcement
+            # is the server's responsibility, so any page that knows (or
+            # scans for) this port could otherwise attach to the dashboard
+            # and read/inject conversation state.
+            origin = request.headers.get("Origin")
+            if not is_allowed_origin(origin, self._port):
+                logger.warning(
+                    "Rejected dashboard WebSocket connection: disallowed Origin %r",
+                    origin,
+                )
+                body = b"Forbidden"
+                return Response(
+                    http.HTTPStatus.FORBIDDEN,
+                    "Forbidden",
+                    websockets.Headers({"Content-Length": str(len(body))}),
+                    body,
+                )
+            # Let the library proceed with the WebSocket upgrade
             return None
 
         # Serve static files

--- a/src/mcp_cli/dashboard/static/js/layout.js
+++ b/src/mcp_cli/dashboard/static/js/layout.js
@@ -9,7 +9,7 @@ import {
   setPanels, incPanelCounter, setLayoutConfig,
   isSidebarView, _sidebarOpen,
 } from './state.js';
-import { makeDraggable, showToast } from './utils.js';
+import { esc, makeDraggable, showToast } from './utils.js';
 import {
   getOrCreateView, attachViewToSlot, iconForView, labelForView, srcForView,
   updatePanelHeader, switchPanelView, populateViewMenu, postToIframe,
@@ -90,8 +90,8 @@ export function createPanelSlot(viewId, rowEl) {
   header.className = 'panel-header';
   header.draggable = true;
   header.innerHTML = `
-    <span class="panel-icon">${iconForView(resolvedViewId)}</span>
-    <button class="panel-view-toggle" title="Switch view">${labelForView(resolvedViewId)} ▾</button>
+    <span class="panel-icon">${esc(iconForView(resolvedViewId))}</span>
+    <button class="panel-view-toggle" title="Switch view">${esc(labelForView(resolvedViewId))} ▾</button>
     <div class="panel-view-menu dropdown-menu"></div>
     <button class="panel-btn" title="Pop out" data-action="popout">⤢</button>
     <button class="panel-btn" title="Minimize" data-action="minimize">−</button>

--- a/src/mcp_cli/dashboard/static/views/agent-terminal.html
+++ b/src/mcp_cli/dashboard/static/views/agent-terminal.html
@@ -6,6 +6,8 @@
 <title>Agent Terminal</title>
 <!-- marked.js for markdown rendering -->
 <script src="https://cdn.jsdelivr.net/npm/marked@9/marked.min.js"></script>
+<!-- DOMPurify to sanitize marked's HTML output before it's ever assigned to innerHTML -->
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
 <!-- highlight.js for syntax highlighting (common languages only) -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11/styles/github-dark.min.css">
 <script src="https://cdn.jsdelivr.net/npm/highlight.js@11/lib/core.min.js"></script>
@@ -654,15 +656,19 @@ function addMessageBubble(role, content, streaming) {
 function renderBubbleContent(bubble, text, streaming) {
   const contentEl = bubble.querySelector('.msg-content');
   if (!contentEl) return;
-  if (typeof marked !== 'undefined' && !streaming) {
+  // Assistant text can be steered by anything an MCP server returns (prompt
+  // injection), so treat marked's HTML output as untrusted and run it
+  // through DOMPurify rather than a hand-rolled regex blocklist — a regex
+  // approach missed things like <svg/onload=...> (no leading whitespace
+  // before the attribute) and <iframe srcdoc="...">.
+  if (
+    typeof marked !== 'undefined' &&
+    typeof DOMPurify !== 'undefined' &&
+    !streaming
+  ) {
     try {
       const html = marked.parse(text);
-      // Sanitize: strip <script>, event handlers, and dangerous URIs
-      const sanitized = html
-        .replace(/<script[\s\S]*?<\/script>/gi, '')
-        .replace(/\son\w+\s*=/gi, ' data-removed=')
-        .replace(/href\s*=\s*["']javascript:/gi, 'href="');
-      contentEl.innerHTML = sanitized;
+      contentEl.innerHTML = DOMPurify.sanitize(html);
       return;
     } catch (e) {
       console.error('Markdown parse error:', e);

--- a/src/mcp_cli/memory/store.py
+++ b/src/mcp_cli/memory/store.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from mcp_cli.config.defaults import (
     DEFAULT_MEMORY_BASE_DIR,
     DEFAULT_MEMORY_MAX_ENTRIES_PER_SCOPE,
+    DEFAULT_MEMORY_MAX_ENTRY_CHARS,
     DEFAULT_MEMORY_MAX_PROMPT_CHARS,
 )
 from mcp_cli.memory.models import MemoryEntry, MemoryScope, MemoryScopeFile
@@ -29,6 +30,7 @@ class MemoryScopeStore:
         workspace_dir: str | None = None,
         max_entries: int = DEFAULT_MEMORY_MAX_ENTRIES_PER_SCOPE,
         max_prompt_chars: int = DEFAULT_MEMORY_MAX_PROMPT_CHARS,
+        max_entry_chars: int = DEFAULT_MEMORY_MAX_ENTRY_CHARS,
     ) -> None:
         self._base_dir = Path(base_dir or DEFAULT_MEMORY_BASE_DIR).expanduser()
         self._workspace_hash = hashlib.sha256(
@@ -36,6 +38,7 @@ class MemoryScopeStore:
         ).hexdigest()[:16]
         self._max_entries = max_entries
         self._max_prompt_chars = max_prompt_chars
+        self._max_entry_chars = max_entry_chars
         self._lock = threading.Lock()
 
         # Ensure directories exist
@@ -48,6 +51,9 @@ class MemoryScopeStore:
 
     def remember(self, scope: MemoryScope, key: str, content: str) -> MemoryEntry:
         """Store or update a memory entry (upsert by key)."""
+        if len(content) > self._max_entry_chars:
+            content = content[: self._max_entry_chars]
+
         with self._lock:
             data = self._load(scope)
             now = datetime.now(timezone.utc)

--- a/src/mcp_cli/planning/backends.py
+++ b/src/mcp_cli/planning/backends.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 from chuk_ai_planner.execution.models import (
@@ -33,6 +34,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+ConfirmPromptCallback = Callable[[str, dict[str, Any]], Awaitable[bool]]
+"""Async callback that asks the user to approve a tool call: (tool_name, arguments) -> approved."""
+
 
 class McpToolBackend:
     """Planner → mcp-cli ToolManager adapter with guard integration.
@@ -44,6 +48,14 @@ class McpToolBackend:
     Guard checks (budget, per-tool limits, runaway detection) are
     enforced before each call. Results are recorded for value binding
     and budget tracking after each call.
+
+    Tool confirmation: the normal chat path gates every tool call through
+    the user's confirm-tools preference and trusted-domain list before
+    executing it. This backend enforces the exact same policy — a plan is
+    just another way a tool call gets made, and it must not bypass a
+    control the user already turned on. If the preference says a call
+    needs confirmation but no confirm_prompt was supplied to actually ask
+    the user, the call is declined rather than silently allowed through.
     """
 
     def __init__(
@@ -52,6 +64,7 @@ class McpToolBackend:
         *,
         namespace: str | None = None,
         enable_guards: bool = True,
+        confirm_prompt: ConfirmPromptCallback | None = None,
     ) -> None:
         """Initialize the MCP tool backend.
 
@@ -59,10 +72,38 @@ class McpToolBackend:
             tool_manager: The ToolManager instance for MCP tool execution.
             namespace: Optional namespace prefix for tool names.
             enable_guards: If True, check guards before each tool call.
+            confirm_prompt: Async (tool_name, arguments) -> bool callback that
+                prompts the user for approval, e.g. ui_manager's
+                do_confirm_tool_execution. When the confirm-tools preference
+                requires confirmation for a tool and this is None, the call
+                is declined (fail closed) rather than executed unconfirmed.
         """
         self._tool_manager = tool_manager
         self._namespace = namespace
         self._enable_guards = enable_guards
+        self._confirm_prompt = confirm_prompt
+
+    async def _should_confirm(self, tool_name: str) -> bool:
+        """Mirror chat/tool_processor.py's _should_confirm_tool policy check."""
+        try:
+            from mcp_cli.utils.preferences import get_preference_manager
+
+            prefs = get_preference_manager()
+
+            server_url: str | None = None
+            try:
+                info = await self._tool_manager.get_tool_by_name(tool_name)
+                if info is not None:
+                    server_url = self._tool_manager._get_server_url(info.namespace)
+            except Exception as e:
+                logger.debug("Could not resolve server URL for %s: %s", tool_name, e)
+
+            if server_url and prefs.is_trusted_domain(server_url):
+                return False
+            return bool(prefs.should_confirm_tool(tool_name))
+        except Exception as e:
+            logger.warning("Error checking tool confirmation preference: %s", e)
+            return True
 
     async def execute_tool(self, request: ToolExecutionRequest) -> ToolExecutionResult:
         """Execute a tool via mcp-cli's ToolManager with guard checks.
@@ -88,6 +129,41 @@ class McpToolBackend:
             tool_name,
             list(request.args.keys()),
         )
+
+        # --- Tool confirmation (same policy as the interactive chat path) ---
+        if await self._should_confirm(tool_name):
+            if self._confirm_prompt is None:
+                duration = time.perf_counter() - start_time
+                logger.warning(
+                    "Plan step %s: tool %s requires confirmation but no "
+                    "confirm_prompt was wired up — declining rather than "
+                    "executing unconfirmed",
+                    request.step_id,
+                    tool_name,
+                )
+                return ToolExecutionResult(
+                    tool_name=request.tool_name,
+                    result=None,
+                    error="Tool execution requires user confirmation, which "
+                    "isn't available in this context",
+                    duration=duration,
+                    cached=False,
+                )
+            approved = await self._confirm_prompt(tool_name, request.args)
+            if not approved:
+                duration = time.perf_counter() - start_time
+                logger.info(
+                    "Plan step %s: tool %s declined by user",
+                    request.step_id,
+                    tool_name,
+                )
+                return ToolExecutionResult(
+                    tool_name=request.tool_name,
+                    result=None,
+                    error="Tool execution declined by user",
+                    duration=duration,
+                    cached=False,
+                )
 
         # --- Guard checks (pre-execution) ---
         if self._enable_guards:

--- a/src/mcp_cli/planning/executor.py
+++ b/src/mcp_cli/planning/executor.py
@@ -34,7 +34,7 @@ from mcp_cli.config.defaults import (
     DEFAULT_PLAN_VARIABLE_SUMMARY_MAX_CHARS,
 )
 from mcp_cli.config.enums import PlanStatus
-from mcp_cli.planning.backends import McpToolBackend
+from mcp_cli.planning.backends import ConfirmPromptCallback, McpToolBackend
 from mcp_cli.planning.context import PlanningContext
 
 logger = logging.getLogger(__name__)
@@ -122,6 +122,7 @@ class PlanRunner:
         on_tool_start: ToolStartCallback | None = None,
         on_tool_complete: ToolCompleteCallback | None = None,
         enable_guards: bool = False,
+        confirm_prompt: ConfirmPromptCallback | None = None,
         max_concurrency: int = DEFAULT_PLAN_MAX_CONCURRENCY,
         max_step_retries: int = DEFAULT_PLAN_MAX_STEP_RETRIES,
     ) -> None:
@@ -139,6 +140,9 @@ class PlanRunner:
             on_tool_complete: Async callback(tool_name, result_str, success, elapsed)
                 after each tool call. Called for each agentic loop tool invocation.
             enable_guards: If True, enforce guard checks during execution.
+            confirm_prompt: Async (tool_name, arguments) -> bool callback used
+                to ask the user for approval before a tool call whose
+                confirm-tools preference requires it — see McpToolBackend.
             max_concurrency: Maximum concurrent steps within a batch.
             max_step_retries: Maximum LLM retry attempts per step on failure.
         """
@@ -155,6 +159,7 @@ class PlanRunner:
         self._backend = McpToolBackend(
             context.tool_manager,
             enable_guards=enable_guards,
+            confirm_prompt=confirm_prompt,
         )
 
         # Tool catalog cache (lazy-loaded, protected by lock for parallel steps)

--- a/src/mcp_cli/planning/executor.py
+++ b/src/mcp_cli/planning/executor.py
@@ -933,7 +933,7 @@ def _resolve_string(value: str, variables: dict[str, Any]) -> Any:
         return resolved if resolved is not None else value
 
     # Template string: "text ${var} more" → string interpolation
-    def replacer(match: re.Match) -> str:
+    def replacer(match: re.Match[str]) -> str:
         var_path = match.group(1)
         resolved = _resolve_path(var_path, variables)
         return str(resolved) if resolved is not None else match.group(0)

--- a/src/mcp_cli/planning/tools.py
+++ b/src/mcp_cli/planning/tools.py
@@ -17,6 +17,7 @@ import json
 import logging
 from typing import Any
 
+from mcp_cli.planning.backends import ConfirmPromptCallback
 from mcp_cli.planning.context import PlanningContext
 
 logger = logging.getLogger(__name__)
@@ -302,12 +303,25 @@ async def _run_plan(
             except Exception:
                 pass
 
+    confirm_prompt: ConfirmPromptCallback | None = None
+    if ui_manager is not None and hasattr(ui_manager, "do_confirm_tool_execution"):
+
+        async def _confirm_prompt(tool_name: str, arguments: dict) -> bool:
+            return bool(
+                await ui_manager.do_confirm_tool_execution(
+                    tool_name=tool_name, arguments=arguments
+                )
+            )
+
+        confirm_prompt = _confirm_prompt
+
     runner = PlanRunner(
         context,
         model_manager=model_manager,
         enable_guards=False,
         on_tool_start=on_tool_start,
         on_tool_complete=on_tool_complete,
+        confirm_prompt=confirm_prompt,
     )
 
     result = await runner.execute_plan(plan_data, checkpoint=False)

--- a/src/mcp_cli/utils/loopback_origin.py
+++ b/src/mcp_cli/utils/loopback_origin.py
@@ -1,0 +1,38 @@
+# mcp_cli/utils/loopback_origin.py
+"""Origin validation shared by mcp-cli's local WebSocket servers.
+
+Both the MCP Apps bridge (``mcp_cli.apps.host``) and the dashboard
+(``mcp_cli.dashboard.server``) run an unauthenticated WebSocket server on
+``localhost`` intended only for the host page they themselves serve. Real
+browsers always attach an ``Origin`` header to WebSocket handshakes, but —
+unlike fetch()/XHR — do not enforce same-origin policy on the connection
+itself; that enforcement is the server's job. Without it, any web page the
+browser loads (unrelated to mcp-cli) could attach to the bridge by simply
+knowing (or scanning for) the port.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+# Loopback hostnames the host page can legitimately be served from.
+_ALLOWED_ORIGIN_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def is_allowed_origin(origin: str | None, port: int) -> bool:
+    """Return True if *origin* is the http://localhost:<port> host page origin.
+
+    Requires an exact match on scheme, loopback host, and port — this is
+    what actually prevents an unrelated page from attaching to the bridge.
+    """
+    if not origin:
+        return False
+    try:
+        parsed = urlsplit(origin)
+    except ValueError:
+        return False
+    if parsed.scheme != "http":
+        return False
+    if parsed.hostname not in _ALLOWED_ORIGIN_HOSTS:
+        return False
+    return parsed.port == port

--- a/src/mcp_cli/utils/loopback_origin.py
+++ b/src/mcp_cli/utils/loopback_origin.py
@@ -29,10 +29,15 @@ def is_allowed_origin(origin: str | None, port: int) -> bool:
         return False
     try:
         parsed = urlsplit(origin)
+        hostname = parsed.hostname
+        origin_port = parsed.port
     except ValueError:
+        # urlsplit()/.hostname/.port can each raise on malformed input
+        # (bad IPv6 literal, non-numeric port, ...) depending on the
+        # Python version, so all three are covered here.
         return False
     if parsed.scheme != "http":
         return False
-    if parsed.hostname not in _ALLOWED_ORIGIN_HOSTS:
+    if hostname not in _ALLOWED_ORIGIN_HOSTS:
         return False
-    return parsed.port == port
+    return origin_port == port

--- a/src/mcp_cli/utils/url_safety.py
+++ b/src/mcp_cli/utils/url_safety.py
@@ -1,0 +1,64 @@
+# mcp_cli/utils/url_safety.py
+"""Outbound URL safety checks — guards against SSRF.
+
+Used wherever mcp-cli fetches a URL supplied by a semi-trusted MCP server
+(e.g. an MCP App's ``resource_uri`` or a tool result's ``viewUrl``). Without
+this check, a malicious or compromised server could point mcp-cli at an
+internal-only service or a cloud metadata endpoint (``169.254.169.254``)
+and have the response rendered back to the user.
+
+Known limitation: this validates the hostname's *current* DNS resolution
+before connecting, so it does not defend against DNS rebinding (an
+attacker-controlled domain with a very short TTL that resolves to a public
+address at check time and a private one at connect time). Closing that
+fully would require a custom transport that connects to the pinned,
+validated IP rather than letting the HTTP client re-resolve the hostname.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlsplit
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+def _is_unsafe_address(addr: str) -> bool:
+    """Return True if *addr* (an IP literal) is not a routable public address."""
+    try:
+        ip = ipaddress.ip_address(addr)
+    except ValueError:
+        return True  # unparsable -> treat as unsafe
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def is_safe_fetch_url(url: str) -> bool:
+    """Return True if *url* is http(s) and every resolved address is public.
+
+    Checks all A/AAAA records for the hostname, not just the first, since a
+    hostname can round-robin between multiple addresses.
+    """
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return False
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        return False
+    host = parsed.hostname
+    if not host:
+        return False
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return False
+    if not infos:
+        return False
+    return all(not _is_unsafe_address(info[4][0]) for info in infos)

--- a/src/mcp_cli/utils/url_safety.py
+++ b/src/mcp_cli/utils/url_safety.py
@@ -48,11 +48,14 @@ def is_safe_fetch_url(url: str) -> bool:
     """
     try:
         parsed = urlsplit(url)
+        host = parsed.hostname
     except ValueError:
+        # urlsplit()/`.hostname` can both raise on malformed input (e.g. a
+        # broken IPv6 literal) - which one depends on the Python version,
+        # so both are covered here rather than just the constructor call.
         return False
     if parsed.scheme not in _ALLOWED_SCHEMES:
         return False
-    host = parsed.hostname
     if not host:
         return False
     try:

--- a/tests/agents/test_group_store.py
+++ b/tests/agents/test_group_store.py
@@ -79,6 +79,24 @@ class TestSaveGroup:
         assert (tmp_path / "b" / "session.json").exists()
 
     @pytest.mark.asyncio
+    async def test_malicious_agent_id_cannot_escape_group_dir(self, tmp_path):
+        """agent_id can originate from an LLM-controllable agent_spawn call
+        (e.g. name="../../../../tmp/evil"); it must not escape group_dir."""
+        cfg = AgentConfig(
+            agent_id="../../../../tmp/evil-agent", name="Evil", role="worker"
+        )
+        mgr = _make_agent_manager(cfg)
+
+        await save_group(mgr, description="attack", group_dir=tmp_path)
+
+        # No session.json should exist outside tmp_path
+        escaped_path = tmp_path.parent.parent.parent.parent / "tmp" / "evil-agent"
+        assert not escaped_path.exists()
+        # The sanitized directory should exist inside tmp_path instead
+        children = list(tmp_path.iterdir())
+        assert all(".." not in c.name and "/" not in c.name for c in children)
+
+    @pytest.mark.asyncio
     async def test_save_preserves_config_fields(self, tmp_path):
         cfg = AgentConfig(
             agent_id="x",

--- a/tests/apps/test_bridge.py
+++ b/tests/apps/test_bridge.py
@@ -313,6 +313,112 @@ class TestHandleMessage:
         assert bridge.app_info.state == AppState.CLOSED
 
 
+class TestToolPermissionEnforcement:
+    """The resource's declared _meta.ui.permissions.tools scope must be honored."""
+
+    def _make_bridge_with_permissions(self, permissions):
+        tm = FakeToolManager()
+        info = AppInfo(
+            tool_name="test-tool",
+            resource_uri="ui://test-tool/app.html",
+            server_name="test-server",
+            port=9470,
+            permissions=permissions,
+        )
+        bridge = AppBridge(info, tm)
+        return bridge, tm
+
+    @pytest.mark.asyncio
+    async def test_no_permissions_declared_allows_any_tool(self):
+        """A resource that declares no permissions imposes no restriction."""
+        bridge, tm = self._make_bridge_with_permissions(None)
+        msg = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "any-tool", "arguments": {}},
+            }
+        )
+        resp = await bridge.handle_message(msg)
+        parsed = json.loads(resp)
+        assert "result" in parsed
+        assert tm.executed_tools == [("any-tool", {}, "test-server")]
+
+    @pytest.mark.asyncio
+    async def test_permissions_without_tools_key_allows_any_tool(self):
+        """A permissions dict that doesn't declare a tools scope isn't restrictive."""
+        bridge, tm = self._make_bridge_with_permissions({"clipboard": True})
+        msg = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "any-tool", "arguments": {}},
+            }
+        )
+        resp = await bridge.handle_message(msg)
+        parsed = json.loads(resp)
+        assert "result" in parsed
+        assert tm.executed_tools == [("any-tool", {}, "test-server")]
+
+    @pytest.mark.asyncio
+    async def test_listed_tool_permitted(self):
+        bridge, tm = self._make_bridge_with_permissions(
+            {"tools": ["refresh_dashboard"]}
+        )
+        msg = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "refresh_dashboard", "arguments": {}},
+            }
+        )
+        resp = await bridge.handle_message(msg)
+        parsed = json.loads(resp)
+        assert "result" in parsed
+        assert tm.executed_tools == [("refresh_dashboard", {}, "test-server")]
+
+    @pytest.mark.asyncio
+    async def test_unlisted_tool_rejected(self):
+        """A tool outside the declared scope must be rejected without calling execute_tool."""
+        bridge, tm = self._make_bridge_with_permissions(
+            {"tools": ["refresh_dashboard"]}
+        )
+        msg = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "read_local_secret_file", "arguments": {}},
+            }
+        )
+        resp = await bridge.handle_message(msg)
+        parsed = json.loads(resp)
+        assert "error" in parsed
+        assert parsed["error"]["code"] == -32603
+        assert "not permitted" in parsed["error"]["message"].lower()
+        assert tm.executed_tools == []
+
+    @pytest.mark.asyncio
+    async def test_empty_tools_list_rejects_everything(self):
+        bridge, tm = self._make_bridge_with_permissions({"tools": []})
+        msg = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "any-tool", "arguments": {}},
+            }
+        )
+        resp = await bridge.handle_message(msg)
+        parsed = json.loads(resp)
+        assert "error" in parsed
+        assert parsed["error"]["code"] == -32603
+        assert tm.executed_tools == []
+
+
 class TestWebSocketLifecycle:
     def test_set_ws_resets_state(self):
         bridge, _ = _make_bridge()

--- a/tests/apps/test_host.py
+++ b/tests/apps/test_host.py
@@ -1681,3 +1681,11 @@ class TestIsAllowedOrigin:
 
     def test_malformed_origin_rejected(self):
         assert _is_allowed_origin("not a url at all", 9470) is False
+
+    def test_non_numeric_port_rejected_without_raising(self):
+        # .port raises ValueError for non-numeric ports on some Python
+        # versions; must be caught, not propagated to the caller.
+        assert _is_allowed_origin("http://localhost:notaport", 9470) is False
+
+    def test_malformed_ipv6_origin_rejected_without_raising(self):
+        assert _is_allowed_origin("http://[invalid::ipv6", 9470) is False

--- a/tests/apps/test_host.py
+++ b/tests/apps/test_host.py
@@ -404,6 +404,7 @@ class TestFetchHttpResource:
         fake_response = MagicMock()
         fake_response.text = "<html>fetched</html>"
         fake_response.headers = {"content-type": "text/html"}
+        fake_response.is_redirect = False
         fake_response.raise_for_status = MagicMock()
 
         fake_client = MagicMock()
@@ -411,7 +412,10 @@ class TestFetchHttpResource:
         fake_client.__aenter__ = AsyncMock(return_value=fake_client)
         fake_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("httpx.AsyncClient", return_value=fake_client):
+        with (
+            patch("httpx.AsyncClient", return_value=fake_client),
+            patch("mcp_cli.apps.host.is_safe_fetch_url", return_value=True),
+        ):
             html, resource = await AppHostServer._fetch_http_resource(
                 "https://example.com/app.html"
             )
@@ -428,6 +432,7 @@ class TestFetchHttpResource:
         import httpx
 
         fake_response = MagicMock()
+        fake_response.is_redirect = False
         fake_response.raise_for_status = MagicMock(
             side_effect=httpx.HTTPStatusError(
                 "404", request=MagicMock(), response=MagicMock()
@@ -439,9 +444,82 @@ class TestFetchHttpResource:
         fake_client.__aenter__ = AsyncMock(return_value=fake_client)
         fake_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("httpx.AsyncClient", return_value=fake_client):
+        with (
+            patch("httpx.AsyncClient", return_value=fake_client),
+            patch("mcp_cli.apps.host.is_safe_fetch_url", return_value=True),
+        ):
             with pytest.raises(httpx.HTTPStatusError):
                 await AppHostServer._fetch_http_resource("https://example.com/missing")
+
+    @pytest.mark.asyncio
+    async def test_rejects_disallowed_url_before_fetching(self):
+        """A URL that fails is_safe_fetch_url is never sent to httpx."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        fake_client = MagicMock()
+        fake_client.get = AsyncMock()
+        fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+        fake_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("httpx.AsyncClient", return_value=fake_client),
+            patch("mcp_cli.apps.host.is_safe_fetch_url", return_value=False),
+        ):
+            with pytest.raises(RuntimeError, match="disallowed URL"):
+                await AppHostServer._fetch_http_resource(
+                    "http://169.254.169.254/latest/meta-data/"
+                )
+
+        fake_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_redirect_to_disallowed_target_is_rejected(self):
+        """A redirect hop pointing at a disallowed URL is rejected, not followed."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+        import httpx
+
+        redirect_response = MagicMock()
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"location": "http://169.254.169.254/secret"}
+        redirect_response.url = httpx.URL("https://example.com/app.html")
+
+        fake_client = MagicMock()
+        fake_client.get = AsyncMock(return_value=redirect_response)
+        fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+        fake_client.__aexit__ = AsyncMock(return_value=False)
+
+        def _fake_is_safe(url):
+            return "169.254.169.254" not in url
+
+        with (
+            patch("httpx.AsyncClient", return_value=fake_client),
+            patch("mcp_cli.apps.host.is_safe_fetch_url", side_effect=_fake_is_safe),
+        ):
+            with pytest.raises(RuntimeError, match="disallowed URL"):
+                await AppHostServer._fetch_http_resource("https://example.com/app.html")
+
+    @pytest.mark.asyncio
+    async def test_too_many_redirects_raises(self):
+        """A redirect chain longer than _MAX_REDIRECTS raises."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+        import httpx
+
+        redirect_response = MagicMock()
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"location": "/next"}
+        redirect_response.url = httpx.URL("https://example.com/app.html")
+
+        fake_client = MagicMock()
+        fake_client.get = AsyncMock(return_value=redirect_response)
+        fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+        fake_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("httpx.AsyncClient", return_value=fake_client),
+            patch("mcp_cli.apps.host.is_safe_fetch_url", return_value=True),
+        ):
+            with pytest.raises(RuntimeError, match="Too many redirects"):
+                await AppHostServer._fetch_http_resource("https://example.com/app.html")
 
 
 # ── ExtractHtml (additional edge cases) ────────────────────────────────────

--- a/tests/apps/test_host.py
+++ b/tests/apps/test_host.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 
-from mcp_cli.apps.host import AppHostServer, _SAFE_CSP_SOURCE
+from mcp_cli.apps.host import AppHostServer, _is_allowed_origin, _SAFE_CSP_SOURCE
 from mcp_cli.apps.models import AppInfo, AppState
 
 
@@ -1106,7 +1106,7 @@ class TestStartServer:
 
     @pytest.mark.asyncio
     async def test_process_request_ws_returns_none(self):
-        """The process_request closure returns None for '/ws' (WS upgrade)."""
+        """The process_request closure returns None for '/ws' with a matching Origin."""
         from unittest.mock import MagicMock, patch
         from mcp_cli.apps.bridge import AppBridge
 
@@ -1126,6 +1126,117 @@ class TestStartServer:
         fake_conn = MagicMock()
         fake_req = MagicMock()
         fake_req.path = "/ws"
+        fake_req.headers = {"Origin": f"http://localhost:{info.port}"}
+
+        response = captured_process_request(fake_conn, fake_req)
+        assert response is None
+
+    async def test_process_request_ws_rejects_cross_origin(self):
+        """The process_request closure returns 403 for '/ws' with a foreign Origin."""
+        from unittest.mock import MagicMock, patch
+        import http
+        from mcp_cli.apps.bridge import AppBridge
+
+        host, info = self._make_host_and_app_info()
+        bridge = AppBridge(info, host.tool_manager)
+
+        captured_process_request = None
+
+        async def capture_serve(handler, host_addr, port, process_request=None):
+            nonlocal captured_process_request
+            captured_process_request = process_request
+            return MagicMock()
+
+        with patch("mcp_cli.apps.host.ws_serve", side_effect=capture_serve):
+            await host._start_server(info, bridge)
+
+        fake_conn = MagicMock()
+        fake_req = MagicMock()
+        fake_req.path = "/ws"
+        fake_req.headers = {"Origin": "https://evil-attacker.example"}
+
+        response = captured_process_request(fake_conn, fake_req)
+        assert response is not None
+        assert response.status_code == http.HTTPStatus.FORBIDDEN
+
+    async def test_process_request_ws_rejects_missing_origin(self):
+        """The process_request closure returns 403 for '/ws' with no Origin header."""
+        from unittest.mock import MagicMock, patch
+        import http
+        from mcp_cli.apps.bridge import AppBridge
+
+        host, info = self._make_host_and_app_info()
+        bridge = AppBridge(info, host.tool_manager)
+
+        captured_process_request = None
+
+        async def capture_serve(handler, host_addr, port, process_request=None):
+            nonlocal captured_process_request
+            captured_process_request = process_request
+            return MagicMock()
+
+        with patch("mcp_cli.apps.host.ws_serve", side_effect=capture_serve):
+            await host._start_server(info, bridge)
+
+        fake_conn = MagicMock()
+        fake_req = MagicMock()
+        fake_req.path = "/ws"
+        fake_req.headers = {}
+
+        response = captured_process_request(fake_conn, fake_req)
+        assert response is not None
+        assert response.status_code == http.HTTPStatus.FORBIDDEN
+
+    async def test_process_request_ws_rejects_wrong_port(self):
+        """A matching host/scheme but wrong port in Origin must still be rejected."""
+        from unittest.mock import MagicMock, patch
+        import http
+        from mcp_cli.apps.bridge import AppBridge
+
+        host, info = self._make_host_and_app_info()
+        bridge = AppBridge(info, host.tool_manager)
+
+        captured_process_request = None
+
+        async def capture_serve(handler, host_addr, port, process_request=None):
+            nonlocal captured_process_request
+            captured_process_request = process_request
+            return MagicMock()
+
+        with patch("mcp_cli.apps.host.ws_serve", side_effect=capture_serve):
+            await host._start_server(info, bridge)
+
+        fake_conn = MagicMock()
+        fake_req = MagicMock()
+        fake_req.path = "/ws"
+        fake_req.headers = {"Origin": f"http://localhost:{info.port + 1}"}
+
+        response = captured_process_request(fake_conn, fake_req)
+        assert response is not None
+        assert response.status_code == http.HTTPStatus.FORBIDDEN
+
+    async def test_process_request_ws_accepts_127_0_0_1_origin(self):
+        """127.0.0.1 is an accepted loopback-equivalent origin host."""
+        from unittest.mock import MagicMock, patch
+        from mcp_cli.apps.bridge import AppBridge
+
+        host, info = self._make_host_and_app_info()
+        bridge = AppBridge(info, host.tool_manager)
+
+        captured_process_request = None
+
+        async def capture_serve(handler, host_addr, port, process_request=None):
+            nonlocal captured_process_request
+            captured_process_request = process_request
+            return MagicMock()
+
+        with patch("mcp_cli.apps.host.ws_serve", side_effect=capture_serve):
+            await host._start_server(info, bridge)
+
+        fake_conn = MagicMock()
+        fake_req = MagicMock()
+        fake_req.path = "/ws"
+        fake_req.headers = {"Origin": f"http://127.0.0.1:{info.port}"}
 
         response = captured_process_request(fake_conn, fake_req)
         assert response is None
@@ -1451,3 +1562,44 @@ class TestLaunchAppBrowserControl:
 
         assert len(browser_calls) == 1
         assert "9999" in browser_calls[0]
+
+
+# ── _is_allowed_origin ──────────────────────────────────────────────────────
+
+
+class TestIsAllowedOrigin:
+    """Unit tests for the WebSocket Origin allow-list check."""
+
+    def test_matching_localhost_origin(self):
+        assert _is_allowed_origin("http://localhost:9470", 9470) is True
+
+    def test_matching_127_0_0_1_origin(self):
+        assert _is_allowed_origin("http://127.0.0.1:9470", 9470) is True
+
+    def test_wrong_port_rejected(self):
+        assert _is_allowed_origin("http://localhost:9471", 9470) is False
+
+    def test_foreign_host_rejected(self):
+        assert _is_allowed_origin("https://evil-attacker.example", 9470) is False
+
+    def test_https_scheme_rejected(self):
+        # The host page is only ever served over http://, never https://.
+        assert _is_allowed_origin("https://localhost:9470", 9470) is False
+
+    def test_none_origin_rejected(self):
+        assert _is_allowed_origin(None, 9470) is False
+
+    def test_empty_string_origin_rejected(self):
+        assert _is_allowed_origin("", 9470) is False
+
+    def test_null_origin_rejected(self):
+        # Browsers send the literal string "null" for opaque origins
+        # (sandboxed iframes, data: URLs, file:// pages).
+        assert _is_allowed_origin("null", 9470) is False
+
+    def test_subdomain_impersonation_rejected(self):
+        # "localhost.evil.example" must not be treated as the loopback host.
+        assert _is_allowed_origin("http://localhost.evil.example:9470", 9470) is False
+
+    def test_malformed_origin_rejected(self):
+        assert _is_allowed_origin("not a url at all", 9470) is False

--- a/tests/chat/test_attachments.py
+++ b/tests/chat/test_attachments.py
@@ -521,6 +521,34 @@ class TestProcessBrowserFile:
         with pytest.raises(ValueError, match="too large"):
             process_browser_file("big.bin", b64, "image/png")
 
+    def test_too_large_rejected_before_decoding(self, monkeypatch):
+        """A grossly oversized payload is rejected via the encoded-length
+        estimate, without ever calling base64.b64decode (DoS hardening —
+        this path is reachable from an unauthenticated dashboard WebSocket
+        client before Origin validation, or from a malicious/compromised
+        one after)."""
+        import base64
+
+        raw = b"\x00" * (DEFAULT_MAX_ATTACHMENT_SIZE_BYTES * 2)
+        b64 = base64.b64encode(raw).decode()
+
+        called = False
+        real_b64decode = base64.b64decode
+
+        def _tracking_b64decode(*args, **kwargs):
+            nonlocal called
+            called = True
+            return real_b64decode(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "mcp_cli.chat.attachments.base64.b64decode", _tracking_b64decode
+        )
+
+        with pytest.raises(ValueError, match="too large"):
+            process_browser_file("big.bin", b64, "image/png")
+
+        assert called is False
+
     def test_unsupported_extension(self):
         import base64
 

--- a/tests/chat/test_session_store.py
+++ b/tests/chat/test_session_store.py
@@ -178,6 +178,22 @@ class TestAgentNamespacing:
         assert store.sessions_dir == tmp_path / "my-agent"
         assert store.sessions_dir.exists()
 
+    def test_agent_id_path_traversal_sanitized(self, tmp_path):
+        """A malicious agent_id (e.g. via agent_spawn's LLM-controlled name)
+        cannot escape sessions_dir via path traversal."""
+        malicious_id = "../../../../tmp/evil-agent"
+        store = SessionStore(sessions_dir=tmp_path, agent_id=malicious_id)
+
+        # Must stay inside tmp_path, not escape to /tmp/evil-agent or similar
+        assert store.sessions_dir.parent == tmp_path
+        assert ".." not in store.sessions_dir.name
+        assert "/" not in store.sessions_dir.name
+
+    def test_agent_id_with_slashes_sanitized(self, tmp_path):
+        malicious_id = "evil/../../agent"
+        store = SessionStore(sessions_dir=tmp_path, agent_id=malicious_id)
+        assert store.sessions_dir.parent == tmp_path
+
 
 class TestAutoSave:
     def test_auto_save_triggers(self):

--- a/tests/dashboard/test_integration.py
+++ b/tests/dashboard/test_integration.py
@@ -25,10 +25,18 @@ websockets = pytest.importorskip("websockets")
 
 
 def _ws_connect(port: int):
-    """Return an async context manager that connects to the WS endpoint."""
+    """Return an async context manager that connects to the WS endpoint.
+
+    Sends a same-origin Origin header, matching what a real browser tab
+    loaded from the dashboard's own host page would send — the server now
+    rejects handshakes with any other Origin (see loopback_origin.py).
+    """
     from websockets.asyncio.client import connect
 
-    return connect(f"ws://localhost:{port}/ws")
+    return connect(
+        f"ws://localhost:{port}/ws",
+        additional_headers={"Origin": f"http://localhost:{port}"},
+    )
 
 
 async def _recv(ws, timeout: float = 2.0):
@@ -310,3 +318,35 @@ class TestBridgeEndToEnd:
 
         registry_msg = next(m for m in msgs if m["type"] == "VIEW_REGISTRY")
         assert any(v["id"] == "stats:main" for v in registry_msg["payload"]["views"])
+
+
+class TestOriginValidation:
+    """The dashboard WebSocket must reject connections from foreign origins."""
+
+    async def test_cross_origin_connection_rejected(self, live_server):
+        from websockets.asyncio.client import connect
+        from websockets.exceptions import InvalidStatus
+
+        _, port = live_server
+        with pytest.raises(InvalidStatus) as exc_info:
+            async with connect(
+                f"ws://localhost:{port}/ws",
+                additional_headers={"Origin": "https://evil-attacker.example"},
+            ):
+                pass
+        assert exc_info.value.response.status_code == 403
+
+    async def test_missing_origin_connection_rejected(self, live_server):
+        from websockets.asyncio.client import connect
+        from websockets.exceptions import InvalidStatus
+
+        _, port = live_server
+        with pytest.raises(InvalidStatus) as exc_info:
+            async with connect(f"ws://localhost:{port}/ws"):
+                pass
+        assert exc_info.value.response.status_code == 403
+
+    async def test_matching_origin_connection_accepted(self, live_server):
+        _, port = live_server
+        async with _ws_connect(port):
+            pass  # no exception = success

--- a/tests/dashboard/test_server_extra.py
+++ b/tests/dashboard/test_server_extra.py
@@ -19,9 +19,10 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
-def _req(path: str):
+def _req(path: str, origin: str | None = None):
     r = MagicMock()
     r.path = path
+    r.headers = {"Origin": origin} if origin is not None else {}
     return r
 
 
@@ -63,14 +64,40 @@ class TestProcessRequest:
         from mcp_cli.dashboard.server import DashboardServer
 
         s = DashboardServer()
-        assert s._process_request(MagicMock(), _req("/ws")) is None
+        s._port = 9120
+        origin = f"http://localhost:{s._port}"
+        assert s._process_request(MagicMock(), _req("/ws", origin=origin)) is None
 
     def test_ws_path_with_query_returns_none(self):
         from mcp_cli.dashboard.server import DashboardServer
 
         s = DashboardServer()
+        s._port = 9120
+        origin = f"http://localhost:{s._port}"
         # Query string should be stripped; /ws?foo=bar still routes to WS
-        assert s._process_request(MagicMock(), _req("/ws?foo=bar")) is None
+        assert (
+            s._process_request(MagicMock(), _req("/ws?foo=bar", origin=origin)) is None
+        )
+
+    def test_ws_path_rejects_cross_origin(self):
+        from mcp_cli.dashboard.server import DashboardServer
+
+        s = DashboardServer()
+        s._port = 9120
+        resp = s._process_request(
+            MagicMock(), _req("/ws", origin="https://evil-attacker.example")
+        )
+        assert resp is not None
+        assert resp.status_code == http.HTTPStatus.FORBIDDEN
+
+    def test_ws_path_rejects_missing_origin(self):
+        from mcp_cli.dashboard.server import DashboardServer
+
+        s = DashboardServer()
+        s._port = 9120
+        resp = s._process_request(MagicMock(), _req("/ws"))
+        assert resp is not None
+        assert resp.status_code == http.HTTPStatus.FORBIDDEN
 
     def test_unknown_path_returns_404(self):
         from mcp_cli.dashboard.server import DashboardServer

--- a/tests/memory/test_store.py
+++ b/tests/memory/test_store.py
@@ -41,6 +41,21 @@ class TestRemember:
         assert len(gl) == 1
         assert gl[0].content == "global_val"
 
+    def test_content_over_max_chars_is_truncated(self, tmp_path: Path):
+        """A single remember() call can't grow a scope file unboundedly."""
+        store = MemoryScopeStore(
+            base_dir=tmp_path, workspace_dir="/test/project", max_entry_chars=100
+        )
+        entry = store.remember(MemoryScope.GLOBAL, "huge", "x" * 10_000)
+        assert len(entry.content) == 100
+
+    def test_content_under_max_chars_is_unaffected(self, tmp_path: Path):
+        store = MemoryScopeStore(
+            base_dir=tmp_path, workspace_dir="/test/project", max_entry_chars=100
+        )
+        entry = store.remember(MemoryScope.GLOBAL, "small", "hello")
+        assert entry.content == "hello"
+
 
 class TestRecall:
     def test_all(self, store: MemoryScopeStore):

--- a/tests/planning/test_backends.py
+++ b/tests/planning/test_backends.py
@@ -22,6 +22,26 @@ from mcp_cli.planning.backends import (
 )
 
 
+# Captured before the autouse fixture below ever patches the class, so tests
+# that want the real policy logic (TestToolConfirmation) can restore it.
+_REAL_SHOULD_CONFIRM = McpToolBackend._should_confirm
+
+
+@pytest.fixture(autouse=True)
+def _bypass_confirmation(monkeypatch):
+    """Most tests in this file exercise execution/guard mechanics, not the
+    confirmation gate itself — bypass it here so they don't need a real
+    PreferenceManager or a confirm_prompt wired up. Confirmation behavior
+    is covered explicitly by TestToolConfirmation below, which re-patches
+    _should_confirm per test as needed.
+    """
+
+    async def _never_confirm(self, tool_name):
+        return False
+
+    monkeypatch.setattr(McpToolBackend, "_should_confirm", _never_confirm)
+
+
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 
@@ -725,3 +745,143 @@ class TestExtractErrorMessage:
         result = _extract_error_message(long_text)
         assert len(result) < 300
         assert result.endswith("...")
+
+
+# ── Tests: Tool Confirmation Gate ────────────────────────────────────────────
+
+
+class TestToolConfirmation:
+    """The planning backend must honor the same confirm-tools policy the
+    interactive chat path enforces — a plan is just another way a tool call
+    gets made, and must not silently bypass a control the user turned on.
+    """
+
+    @pytest.mark.asyncio
+    async def test_confirmed_call_executes(self, monkeypatch):
+        """When confirmation is required and the user approves, the tool runs."""
+
+        async def _always_confirm(self, tool_name):
+            return True
+
+        monkeypatch.setattr(McpToolBackend, "_should_confirm", _always_confirm)
+
+        approvals: list[tuple[str, dict]] = []
+
+        async def confirm_prompt(tool_name, args):
+            approvals.append((tool_name, args))
+            return True
+
+        tm = FakeToolManager(result="ok")
+        backend = McpToolBackend(tm, enable_guards=False, confirm_prompt=confirm_prompt)
+
+        request = ToolExecutionRequest(
+            tool_name="delete_file", args={"path": "/tmp/x"}, step_id="step-1"
+        )
+        result = await backend.execute_tool(request)
+
+        assert result.success
+        assert approvals == [("delete_file", {"path": "/tmp/x"})]
+        assert len(tm.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_declined_call_is_not_executed(self, monkeypatch):
+        """When the user declines, the tool must never reach ToolManager."""
+
+        async def _always_confirm(self, tool_name):
+            return True
+
+        monkeypatch.setattr(McpToolBackend, "_should_confirm", _always_confirm)
+
+        async def confirm_prompt(tool_name, args):
+            return False
+
+        tm = FakeToolManager(result="should not see this")
+        backend = McpToolBackend(tm, enable_guards=False, confirm_prompt=confirm_prompt)
+
+        request = ToolExecutionRequest(
+            tool_name="delete_file", args={"path": "/tmp/x"}, step_id="step-1"
+        )
+        result = await backend.execute_tool(request)
+
+        assert not result.success
+        assert "declined" in result.error.lower()
+        assert len(tm.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_prompt_fails_closed(self, monkeypatch):
+        """If confirmation is required but nothing can ask the user, deny —
+        never silently execute unconfirmed."""
+
+        async def _always_confirm(self, tool_name):
+            return True
+
+        monkeypatch.setattr(McpToolBackend, "_should_confirm", _always_confirm)
+
+        tm = FakeToolManager(result="should not see this")
+        backend = McpToolBackend(tm, enable_guards=False, confirm_prompt=None)
+
+        request = ToolExecutionRequest(
+            tool_name="delete_file", args={"path": "/tmp/x"}, step_id="step-1"
+        )
+        result = await backend.execute_tool(request)
+
+        assert not result.success
+        assert "confirmation" in result.error.lower()
+        assert len(tm.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_confirmation_required_executes_without_prompt(self, monkeypatch):
+        """Trusted/never-confirm tools execute even with no confirm_prompt wired."""
+
+        async def _never_confirm(self, tool_name):
+            return False
+
+        monkeypatch.setattr(McpToolBackend, "_should_confirm", _never_confirm)
+
+        tm = FakeToolManager(result="ok")
+        backend = McpToolBackend(tm, enable_guards=False, confirm_prompt=None)
+
+        request = ToolExecutionRequest(
+            tool_name="read_file", args={"path": "/tmp/x"}, step_id="step-1"
+        )
+        result = await backend.execute_tool(request)
+
+        assert result.success
+        assert len(tm.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_should_confirm_uses_preference_manager(self, monkeypatch):
+        """_should_confirm defers to get_preference_manager()'s policy."""
+        monkeypatch.setattr(McpToolBackend, "_should_confirm", _REAL_SHOULD_CONFIRM)
+        tm = FakeToolManager(result="ok")
+        backend = McpToolBackend(tm, enable_guards=False)
+
+        fake_prefs = MagicMock()
+        fake_prefs.is_trusted_domain.return_value = False
+        fake_prefs.should_confirm_tool.return_value = True
+
+        with patch(
+            "mcp_cli.utils.preferences.get_preference_manager",
+            return_value=fake_prefs,
+        ):
+            assert await backend._should_confirm("delete_file") is True
+
+        fake_prefs.should_confirm_tool.return_value = False
+        with patch(
+            "mcp_cli.utils.preferences.get_preference_manager",
+            return_value=fake_prefs,
+        ):
+            assert await backend._should_confirm("read_file") is False
+
+    @pytest.mark.asyncio
+    async def test_should_confirm_fails_closed_on_error(self, monkeypatch):
+        """Any error while checking preferences must default to requiring confirmation."""
+        monkeypatch.setattr(McpToolBackend, "_should_confirm", _REAL_SHOULD_CONFIRM)
+        tm = FakeToolManager(result="ok")
+        backend = McpToolBackend(tm, enable_guards=False)
+
+        with patch(
+            "mcp_cli.utils.preferences.get_preference_manager",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert await backend._should_confirm("delete_file") is True

--- a/tests/planning/test_backends.py
+++ b/tests/planning/test_backends.py
@@ -885,3 +885,59 @@ class TestToolConfirmation:
             side_effect=RuntimeError("boom"),
         ):
             assert await backend._should_confirm("delete_file") is True
+
+    @pytest.mark.asyncio
+    async def test_should_confirm_trusted_domain_bypasses(self, monkeypatch):
+        """A tool from a trusted-domain server skips confirmation, mirroring
+        the interactive chat path's is_trusted_domain fast path."""
+        monkeypatch.setattr(McpToolBackend, "_should_confirm", _REAL_SHOULD_CONFIRM)
+
+        class FakeToolInfo:
+            namespace = "trusted-server"
+
+        tm = FakeToolManager(result="ok")
+        tm.get_tool_by_name = lambda tool_name: _async_return(FakeToolInfo())
+        tm._get_server_url = lambda namespace: "https://trusted.example.com"
+        backend = McpToolBackend(tm, enable_guards=False)
+
+        fake_prefs = MagicMock()
+        fake_prefs.is_trusted_domain.return_value = True
+        fake_prefs.should_confirm_tool.return_value = True  # should never be reached
+
+        with patch(
+            "mcp_cli.utils.preferences.get_preference_manager",
+            return_value=fake_prefs,
+        ):
+            assert await backend._should_confirm("read_file") is False
+
+        fake_prefs.is_trusted_domain.assert_called_once_with(
+            "https://trusted.example.com"
+        )
+        fake_prefs.should_confirm_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_confirm_untrusted_domain_falls_through(self, monkeypatch):
+        """A resolvable but untrusted server URL still defers to should_confirm_tool."""
+        monkeypatch.setattr(McpToolBackend, "_should_confirm", _REAL_SHOULD_CONFIRM)
+
+        class FakeToolInfo:
+            namespace = "random-server"
+
+        tm = FakeToolManager(result="ok")
+        tm.get_tool_by_name = lambda tool_name: _async_return(FakeToolInfo())
+        tm._get_server_url = lambda namespace: "https://untrusted.example.com"
+        backend = McpToolBackend(tm, enable_guards=False)
+
+        fake_prefs = MagicMock()
+        fake_prefs.is_trusted_domain.return_value = False
+        fake_prefs.should_confirm_tool.return_value = True
+
+        with patch(
+            "mcp_cli.utils.preferences.get_preference_manager",
+            return_value=fake_prefs,
+        ):
+            assert await backend._should_confirm("delete_file") is True
+
+
+async def _async_return(value):
+    return value

--- a/tests/planning/test_executor.py
+++ b/tests/planning/test_executor.py
@@ -27,6 +27,20 @@ from mcp_cli.planning.executor import (
     _parse_tool_call_entry,
 )
 from mcp_cli.planning.context import PlanningContext
+from mcp_cli.planning.backends import McpToolBackend
+
+
+@pytest.fixture(autouse=True)
+def _bypass_confirmation(monkeypatch):
+    """These tests exercise plan execution mechanics (batching, retries,
+    checkpoints, variable resolution), not the tool-confirmation gate —
+    see tests/planning/test_backends.py::TestToolConfirmation for that.
+    """
+
+    async def _never_confirm(self, tool_name):
+        return False
+
+    monkeypatch.setattr(McpToolBackend, "_should_confirm", _never_confirm)
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────

--- a/tests/utils/test_url_safety.py
+++ b/tests/utils/test_url_safety.py
@@ -1,0 +1,69 @@
+# tests/utils/test_url_safety.py
+"""Tests for the outbound URL SSRF guard used by MCP Apps' resource fetch."""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import patch
+
+from mcp_cli.utils.url_safety import is_safe_fetch_url
+
+
+def _fake_addrinfo(addr: str):
+    return [(2, 1, 6, "", (addr, 443))]
+
+
+class TestIsSafeFetchUrl:
+    def test_public_ip_allowed(self):
+        with patch(
+            "mcp_cli.utils.url_safety.socket.getaddrinfo",
+            return_value=_fake_addrinfo("93.184.216.34"),
+        ):
+            assert is_safe_fetch_url("https://example.com/app.html") is True
+
+    def test_link_local_metadata_address_rejected(self):
+        with patch(
+            "mcp_cli.utils.url_safety.socket.getaddrinfo",
+            return_value=_fake_addrinfo("169.254.169.254"),
+        ):
+            assert is_safe_fetch_url("http://metadata.example/latest/") is False
+
+    def test_loopback_ip_literal_rejected(self):
+        assert is_safe_fetch_url("http://127.0.0.1:8080/admin") is False
+
+    def test_private_range_ip_literal_rejected(self):
+        assert is_safe_fetch_url("http://10.0.0.5/internal") is False
+        assert is_safe_fetch_url("http://192.168.1.1/internal") is False
+        assert is_safe_fetch_url("http://172.16.0.1/internal") is False
+
+    def test_ipv6_loopback_rejected(self):
+        assert is_safe_fetch_url("http://[::1]:8080/") is False
+
+    def test_non_http_scheme_rejected(self):
+        assert is_safe_fetch_url("file:///etc/passwd") is False
+        assert is_safe_fetch_url("gopher://example.com/") is False
+        assert is_safe_fetch_url("javascript:alert(1)") is False
+
+    def test_missing_hostname_rejected(self):
+        assert is_safe_fetch_url("http://") is False
+
+    def test_unresolvable_hostname_rejected(self):
+        with patch(
+            "mcp_cli.utils.url_safety.socket.getaddrinfo",
+            side_effect=socket.gaierror("nodename nor servname provided"),
+        ):
+            assert is_safe_fetch_url("https://this-does-not-resolve.invalid/") is False
+
+    def test_one_bad_address_among_many_rejects_whole_hostname(self):
+        """If ANY resolved address is unsafe, the whole URL is rejected."""
+        with patch(
+            "mcp_cli.utils.url_safety.socket.getaddrinfo",
+            return_value=[
+                (2, 1, 6, "", ("93.184.216.34", 443)),
+                (2, 1, 6, "", ("169.254.169.254", 443)),
+            ],
+        ):
+            assert is_safe_fetch_url("https://round-robin.example/") is False
+
+    def test_malformed_url_rejected(self):
+        assert is_safe_fetch_url("not a url at all") is False

--- a/tests/utils/test_url_safety.py
+++ b/tests/utils/test_url_safety.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import socket
 from unittest.mock import patch
 
-from mcp_cli.utils.url_safety import is_safe_fetch_url
+from mcp_cli.utils.url_safety import _is_unsafe_address, is_safe_fetch_url
 
 
 def _fake_addrinfo(addr: str):
@@ -67,3 +67,25 @@ class TestIsSafeFetchUrl:
 
     def test_malformed_url_rejected(self):
         assert is_safe_fetch_url("not a url at all") is False
+
+    def test_malformed_ipv6_literal_rejected(self):
+        """Whether the raise happens in urlsplit() or on .hostname access is
+        Python-version-dependent — both must be caught, not just one."""
+        assert is_safe_fetch_url("http://[invalid::ipv6/path") is False
+
+    def test_empty_addrinfo_rejected(self):
+        """getaddrinfo() returning an empty list (no raise) must not be
+        treated as vacuously safe."""
+        with patch(
+            "mcp_cli.utils.url_safety.socket.getaddrinfo",
+            return_value=[],
+        ):
+            assert is_safe_fetch_url("https://no-records.example/") is False
+
+
+class TestIsUnsafeAddress:
+    def test_public_address_is_safe(self):
+        assert _is_unsafe_address("93.184.216.34") is False
+
+    def test_unparsable_address_treated_as_unsafe(self):
+        assert _is_unsafe_address("not-an-ip-address") is True

--- a/uv.lock
+++ b/uv.lock
@@ -1669,7 +1669,7 @@ wheels = [
 
 [[package]]
 name = "mcp-cli"
-version = "0.20"
+version = "0.20.1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncio" },


### PR DESCRIPTION
## Summary

Five independently-verified security fixes, bumping to v0.20.1:

1. **Cross-Site WebSocket Hijacking (CSWSH) in MCP Apps** (`src/mcp_cli/apps/host.py`) — the local app-host WebSocket server accepted connections from any `Origin`, letting an unrelated webpage attach to a running app's bridge and invoke tools, bypassing the resource's declared tool permissions entirely (`AppInfo.permissions` was extracted but never enforced). Fixed with Origin validation on the handshake (`mcp_cli/utils/loopback_origin.py`) and enforcement of the resource's declared `tools` allow-list in `AppBridge._handle_tool_call()`.

2. **Same CSWSH gap in the dashboard** (`src/mcp_cli/dashboard/server.py`) — same missing-Origin-validation pattern, larger blast radius: full conversation history / system prompt disclosure via broadcast, arbitrary tool execution via `REQUEST_TOOL` with zero validation (not even a tool-name regex), and prompt injection via fake `USER_MESSAGE`. This matches the independently-filed GHSA-2jhq-9cjp-44gp (CVSS 8.8 High, CWE-346) for the dashboard-specific case. Fixed with the same shared Origin-validation module.

3. **SSRF in MCP Apps resource fetch** — `_fetch_http_resource()` fetched `resource_uri`/`viewUrl` (both controlled by the connected MCP server) with `follow_redirects=True` and no host/IP validation. Added `mcp_cli/utils/url_safety.py`, validated before the initial request and at every redirect hop.

4. **XSS in the dashboard's markdown renderer and view metadata** — a hand-rolled regex "sanitizer" missed `<svg/onload=...>` and `<iframe srcdoc="...">`; replaced with DOMPurify (verified against both bypasses). Server-declared view name/icon also went unescaped into `innerHTML` in one call site; now escaped.

5. **Planning executor bypassed tool confirmation entirely** — `McpToolBackend` called `ToolManager.execute_tool()` directly with no `is_trusted_domain`/`should_confirm_tool` check anywhere in the planning subsystem, reachable via the always-available `/plan` command or autonomously via the LLM when `--plan-tools` is enabled. Added a `confirm_prompt` gate wired through all three real call sites; fails closed (declines) if confirmation is required but no prompt is available.

Also fixed: path traversal via `agent_spawn`'s unsanitized `agent_id`, a memory-entry size cap, an attachment-decode-before-size-check ordering issue, and two Python-version-dependent unhandled `ValueError` bugs in the new Origin/URL validators found while improving test coverage (both now at 100%). Plus the 3 pre-existing (unrelated) mypy errors on `main`.

Not fixed here: the OAuth `state` CSRF parameter is generated but never validated in the primary authorization-code flow — that code now lives in the external `chuk-mcp-client-oauth` dependency, not this repository.

## Test plan
- [x] Full suite: 4497 passed, 12 skipped
- [x] Coverage: 92%+ overall; both new security modules (`url_safety.py`, `loopback_origin.py`) at 100%
- [x] `ruff check` / `ruff format --check` clean (aside from pre-existing unrelated files)
- [x] `mypy src` clean (0 errors, down from 3 pre-existing)
- [x] Live end-to-end verification against real sockets for both CSWSH fixes (cross-origin/no-origin rejected at handshake; same-origin + declared-permission tools still work)
- [x] DOMPurify sanitization verified against the actual bypass payloads via a real jsdom run